### PR TITLE
Feature/adding santa christmas exchange

### DIFF
--- a/src/ArtifactsMMO.NET/Endpoints/MyCharacters/IMyCharacters.cs
+++ b/src/ArtifactsMMO.NET/Endpoints/MyCharacters/IMyCharacters.cs
@@ -306,5 +306,16 @@ namespace ArtifactsMMO.NET.Endpoints.MyCharacters
         /// The task result contains a read-only collection of <see cref="Character"/> instances.</returns>
         /// <exception cref="ApiException"></exception>
         Task<IReadOnlyCollection<Character>> GetMyCharactersAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Exchange 1 gift for a random reward
+        /// </summary>
+        /// <param name="name">The name of the character exchanging task rewards.</param>
+        /// <param name="cancellationToken">A token for canceling the asynchronous operation.</param>
+        /// <returns>A task representing the asynchronous operation.
+        /// The task result contains a tuple with the <see cref="TaskRewardData"/>
+        /// and an optional <see cref="TaskExchangeError"/>.</returns>
+        /// <exception cref="ApiException"></exception>
+        Task<(TaskRewardData result, TaskExchangeError? error)> ChristmasExchangeAsync(string name, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ArtifactsMMO.NET/Endpoints/MyCharacters/MyCharacters.cs
+++ b/src/ArtifactsMMO.NET/Endpoints/MyCharacters/MyCharacters.cs
@@ -176,5 +176,11 @@ namespace ArtifactsMMO.NET.Endpoints.MyCharacters
         {
             return await GetAsync<IReadOnlyCollection<Character>>($"my/characters", cancellationToken).ConfigureAwait(false);
         }
+
+        public async Task<(TaskRewardData result, TaskExchangeError? error)> ChristmasExchangeAsync(string name, CancellationToken cancellationToken = default)
+        {
+            _nameValidator.Validate(name);
+            return await PostAsync<TaskRewardData, TaskExchangeError>($"my/{name}/action/christmas/exchange", null, cancellationToken).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Adding christmas exchange method. Exact same signature as task exchange. It has the same schema according to the API doc, so I kept the same return objects:

https://api.artifactsmmo.com/docs/#/operations/action_christmas_exchange_my__name__action_christmas_exchange_post

Note, https://github.com/MaxNau/ArtifactsMMO.NET/pull/32 has to be merged first.