### PR TITLE
Adding the missing payload for the NPC Buy/Sell requests

### DIFF
--- a/src/ArtifactsMMO.NET/Endpoints/MyCharacters/IMyCharacters.cs
+++ b/src/ArtifactsMMO.NET/Endpoints/MyCharacters/IMyCharacters.cs
@@ -201,23 +201,25 @@ namespace ArtifactsMMO.NET.Endpoints.MyCharacters
         /// Buy an item from an NPC on the character's map.
         /// </summary>
         /// <param name="name">The name of the character buying the item.</param>
+        /// <param name="npcBuyItemRequest">The request <see cref="NpcBuyItemRequest"/> containing details about the item to buy.</param>
         /// <param name="cancellationToken">A token for canceling the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.
         /// The task result contains a tuple with the <see cref="NpcMerchantTransaction"/>
         /// and an optional <see cref="NpcBuyItemError"/>.</returns>
         /// <exception cref="ApiException"></exception>
-        Task<(NpcMerchantTransaction result, NpcBuyItemError? error)> NpcBuyItemAsync(string name, CancellationToken cancellationToken = default);
+        Task<(NpcMerchantTransaction result, NpcBuyItemError? error)> NpcBuyItemAsync(string name, NpcBuyItemRequest npcBuyItemRequest, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sell an item from an NPC on the character's map.
         /// </summary>
         /// <param name="name">The name of the character selling the item.</param>
+        /// <param name="npcSellItemRequest">The request <see cref="NpcSellItemRequest"/> containing details about the item to sell.</param>
         /// <param name="cancellationToken">A token for canceling the asynchronous operation.</param>
         /// <returns>A task representing the asynchronous operation.
         /// The task result contains a tuple with the <see cref="NpcMerchantTransaction"/>
         /// and an optional <see cref="NpcSellItemError"/>.</returns>
         /// <exception cref="ApiException"></exception>
-        Task<(NpcMerchantTransaction result, NpcSellItemError? error)> NpcSellItemAsync(string name, CancellationToken cancellationToken = default);
+        Task<(NpcMerchantTransaction result, NpcSellItemError? error)> NpcSellItemAsync(string name, NpcSellItemRequest npcSellItemRequest, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Accepting a new task.

--- a/src/ArtifactsMMO.NET/Endpoints/MyCharacters/MyCharacters.cs
+++ b/src/ArtifactsMMO.NET/Endpoints/MyCharacters/MyCharacters.cs
@@ -120,16 +120,16 @@ namespace ArtifactsMMO.NET.Endpoints.MyCharacters
             return await PostAsync<BankExtensionTransaction, BuyBankExpansionError>($"my/{name}/action/bank/buy_expansion", null, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<(NpcMerchantTransaction result, NpcBuyItemError? error)> NpcBuyItemAsync(string name, CancellationToken cancellationToken = default)
+        public async Task<(NpcMerchantTransaction result, NpcBuyItemError? error)> NpcBuyItemAsync(string name, NpcBuyItemRequest npcBuyItemRequest, CancellationToken cancellationToken = default)
         {
             _nameValidator.Validate(name);
-            return await PostAsync<NpcMerchantTransaction, NpcBuyItemError>($"my/{name}/action/npc/buy", null, cancellationToken).ConfigureAwait(false);
+            return await PostAsync<NpcMerchantTransaction, NpcBuyItemError>($"my/{name}/action/npc/buy", npcBuyItemRequest, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<(NpcMerchantTransaction result, NpcSellItemError? error)> NpcSellItemAsync(string name, CancellationToken cancellationToken = default)
+        public async Task<(NpcMerchantTransaction result, NpcSellItemError? error)> NpcSellItemAsync(string name, NpcSellItemRequest npcSellItemRequest, CancellationToken cancellationToken = default)
         {
             _nameValidator.Validate(name);
-            return await PostAsync<NpcMerchantTransaction, NpcSellItemError>($"my/{name}/action/npc/sell", null, cancellationToken).ConfigureAwait(false);
+            return await PostAsync<NpcMerchantTransaction, NpcSellItemError>($"my/{name}/action/npc/sell", npcSellItemRequest, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<(TaskData result, AcceptNewTaskError? error)> AcceptNewTaskAsync(string name, CancellationToken cancellationToken = default)

--- a/src/ArtifactsMMO.NET/Exceptions/DisallowedNpcQuantity.cs
+++ b/src/ArtifactsMMO.NET/Exceptions/DisallowedNpcQuantity.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace ArtifactsMMO.NET.Exceptions
+{
+    /// <summary>
+    /// Represents an exception that is thrown when an invalid quantity for a NPC transaction is specified.
+    /// </summary>
+    /// <remarks>
+    /// This exception indicates that the provided quantity for a NPC transaction 
+    /// is outside the allowed range. The valid quantity must be between 1 and 100, inclusive.
+    /// </remarks>
+    public class DisallowedNpcQuantity : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisallowedNpcQuantity"/> class 
+        /// with a default error message.
+        /// </summary>
+        internal DisallowedNpcQuantity()
+            : base("Should be in range from 1 to 100 inclusive.")
+        {
+        }
+    }
+}

--- a/src/ArtifactsMMO.NET/Requests/NpcBuyItemRequest.cs
+++ b/src/ArtifactsMMO.NET/Requests/NpcBuyItemRequest.cs
@@ -1,0 +1,36 @@
+﻿using ArtifactsMMO.NET.Exceptions;
+using ArtifactsMMO.NET.Validators;
+
+namespace ArtifactsMMO.NET.Requests
+{
+    /// <summary>
+    /// Request to buy an item to the NPC.
+    /// </summary>
+    public class NpcBuyItemRequest : IRequest
+    {
+        private static readonly IValidator<NpcBuyItemRequest> _validator = new NpcBuyItemRequestValidator();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpcBuyItemRequest"/> class.
+        /// </summary>
+        /// <param name="code">The code representing the item to buy or sell to the NPC.</param>
+        /// <param name="quantity">The number of items to buy/sell.</param>
+        /// <exception cref="ItemCodeHasDisallowedCharacters">Thrown when <paramref name="code"/> contains not allowed characters. Should match pattern ^[a-zA-Z0-9_-]+$</exception>
+        /// <exception cref="DisallowedNpcQuantity">Thrown when <paramref name="quantity"/> is not from 1 to 100 inclusive.</exception>
+        public NpcBuyItemRequest(string code, int quantity)
+        {
+            Code = code;
+            Quantity = quantity;
+            _validator.Validate(this);
+        }
+        /// <summary>
+        /// Item code.
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Item quantity.
+        /// </summary>
+        public int Quantity { get; }
+    }
+}

--- a/src/ArtifactsMMO.NET/Requests/NpcSellItemRequest.cs
+++ b/src/ArtifactsMMO.NET/Requests/NpcSellItemRequest.cs
@@ -1,0 +1,36 @@
+﻿using ArtifactsMMO.NET.Exceptions;
+using ArtifactsMMO.NET.Validators;
+
+namespace ArtifactsMMO.NET.Requests
+{
+    /// <summary>
+    /// Request to sell an item to the NPC.
+    /// </summary>
+    public class NpcSellItemRequest : IRequest
+    {
+        private static readonly IValidator<NpcSellItemRequest> _validator = new NpcSellItemRequestValidator();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpcSellItemRequest"/> class.
+        /// </summary>
+        /// <param name="code">The code representing the item to buy or sell to the NPC.</param>
+        /// <param name="quantity">The number of items to buy/sell.</param>
+        /// <exception cref="ItemCodeHasDisallowedCharacters">Thrown when <paramref name="code"/> contains not allowed characters. Should match pattern ^[a-zA-Z0-9_-]+$</exception>
+        /// <exception cref="DisallowedNpcQuantity">Thrown when <paramref name="quantity"/> is not from 1 to 100 inclusive.</exception>
+        public NpcSellItemRequest(string code, int quantity)
+        {
+            Code = code;
+            Quantity = quantity;
+            _validator.Validate(this);
+        }
+        /// <summary>
+        /// Item code.
+        /// </summary>
+        public string Code { get; }
+
+        /// <summary>
+        /// Item quantity.
+        /// </summary>
+        public int Quantity { get; }
+    }
+}

--- a/src/ArtifactsMMO.NET/Validators/NpcBuyItemRequestValidator.cs
+++ b/src/ArtifactsMMO.NET/Validators/NpcBuyItemRequestValidator.cs
@@ -1,0 +1,22 @@
+﻿using ArtifactsMMO.NET.Exceptions;
+using ArtifactsMMO.NET.Requests;
+using ArtifactsMMO.NET.Validators.Static;
+
+namespace ArtifactsMMO.NET.Validators
+{
+    internal class NpcBuyItemRequestValidator : IValidator<NpcBuyItemRequest>
+    {
+        public void Validate(NpcBuyItemRequest request)
+        {
+            if (!AlphaNumericUnderscoreHyphenValidator.IsValid(request.Code))
+            {
+                throw new ItemCodeHasDisallowedCharacters();
+            }
+
+            if (!NpcQuantityValidator.IsValid(request.Quantity))
+            {
+                throw new DisallowedNpcQuantity();
+            }
+        }
+    }
+}

--- a/src/ArtifactsMMO.NET/Validators/NpcSellItemRequestValidator.cs
+++ b/src/ArtifactsMMO.NET/Validators/NpcSellItemRequestValidator.cs
@@ -1,0 +1,22 @@
+﻿using ArtifactsMMO.NET.Exceptions;
+using ArtifactsMMO.NET.Requests;
+using ArtifactsMMO.NET.Validators.Static;
+
+namespace ArtifactsMMO.NET.Validators
+{
+    internal class NpcSellItemRequestValidator : IValidator<NpcSellItemRequest>
+    {
+        public void Validate(NpcSellItemRequest request)
+        {
+            if (!AlphaNumericUnderscoreHyphenValidator.IsValid(request.Code))
+            {
+                throw new ItemCodeHasDisallowedCharacters();
+            }
+
+            if (!NpcQuantityValidator.IsValid(request.Quantity))
+            {
+                throw new DisallowedNpcQuantity();
+            }
+        }
+    }
+}

--- a/src/ArtifactsMMO.NET/Validators/Static/NpcQuantityValidator.cs
+++ b/src/ArtifactsMMO.NET/Validators/Static/NpcQuantityValidator.cs
@@ -1,0 +1,19 @@
+﻿namespace ArtifactsMMO.NET.Validators.Static
+{
+    internal class NpcQuantityValidator
+    {
+        internal static bool IsValid(int quantity)
+        {
+            if (quantity <= 0)
+            {
+                return false;
+            }
+            else if (quantity > 100)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
The currently implemented buy/sell request doesn't have the needed payload to indicate which object to buy/sell.
Documentation:
https://api.artifactsmmo.com/docs/#/operations/action_npc_buy_item_my__name__action_npc_buy_post
https://api.artifactsmmo.com/docs/#/operations/action_npc_sell_item_my__name__action_npc_sell_post

It would be nice if you could issue a release with the fix.